### PR TITLE
Show correct time for durations > 60 hours

### DIFF
--- a/humanize_duration.fish
+++ b/humanize_duration.fish
@@ -2,7 +2,9 @@ function humanize_duration -d "Make a time interval human readable"
     command awk '
         function hmTime(time,   stamp) {
             split("h:m:s:ms", units, ":")
-            for (i = 2; i >= -1; i--) {
+            t = int(time / (60 ^ 2 * 1000))
+            stamp = stamp t units[1] " "  
+            for (i = 1; i >= -1; i--) {
                 if (t = int( i < 0 ? time % 1000 : time / (60 ^ i * 1000) % 60 )) {
                     stamp = stamp t units[sqrt((i - 2) ^ 2) + 1] " "
                 }


### PR DESCRIPTION
The `% 60` in the for loop causes durations longer than 60 hours to be miscalculated.
Came across this after running a badblocks command which took 90 hours,
but my shell prompt that uses humanize_duration showed 30 hours.