### PR TITLE
Rewrite using fish builtins

### DIFF
--- a/humanize_duration.fish
+++ b/humanize_duration.fish
@@ -1,19 +1,23 @@
 function humanize_duration -d "Make a time interval human readable"
-    command awk '
-        function hmTime(time,   stamp) {
-            split("h:m:s:ms", units, ":")
-            for (i = 2; i >= -1; i--) {
-                if (t = int( i < 0 ? time % 1000 : time / (60 ^ i * 1000) % 60 )) {
-                    stamp = stamp t units[sqrt((i - 2) ^ 2) + 1] " "
-                }
-            }
-            if (stamp ~ /^ *$/) {
-                return "0ms"
-            }
-            return substr(stamp, 1, length(stamp) - 1)
-        }
-        { 
-            print hmTime($0) 
-        }
-    '
+    if not string length --quiet $argv
+         set --erase argv
+         read --line argv
+    end
+    set hours (math --scale=0 $argv/\(3600 \*1000\))
+    set mins (math --scale=0 $argv/\(60 \*1000\) % 60)
+    set secs (math --scale=0 $argv % 1000)
+    if test $hours -gt 0
+        set --append output $hours"h"
+    end
+    if test $mins -gt 0
+        set --append output $mins"m"
+    end
+    if test $secs -gt 0
+        set --append output $secs"s"
+    end
+    if not set --query output
+        echo $argv"ms"
+    else
+        echo $output
+    end
 end

--- a/humanize_duration.fish
+++ b/humanize_duration.fish
@@ -5,7 +5,7 @@ function humanize_duration -d "Make a time interval human readable"
     end
     set hours (math --scale=0 $argv/\(3600 \*1000\))
     set mins (math --scale=0 $argv/\(60 \*1000\) % 60)
-    set secs (math --scale=0 $argv % 1000)
+    set secs (math --scale=0 $argv/1000 % 60)
     if test $hours -gt 0
         set --append output $hours"h"
     end


### PR DESCRIPTION
Over 5x faster than current awk script, and keeps everything nice and fishy.

Benchmark: `time for i in (seq 50); random 1 99999999 | humanize_duration; end`

current: 
| Executed in  | 183.48 millis| fish | external |
| ------------- | ------------- | ------------- | ------------- |
|   usr time   |  116.28 millis  | 16.08 millis |  100.20 millis |
|    sys time    |   56.10 millis   | 13.87 millis   | 42.23 millis |


this PR:
| Executed in  | 31.10 millis | fish | external |
| ------------- | ------------- | ------------- | ------------- |
|   usr time   |  27.07 millis  | 26.50 millis |  575.00 millis |
|    sys time    |   7.04 millis   | 7.04 millis   | 0.00 millis |

This PR also adds the ability for arguments to be supplied directly to the function rather than having to be piped in.